### PR TITLE
Enable placeholders for charts

### DIFF
--- a/src/pptxGenerator.js
+++ b/src/pptxGenerator.js
@@ -194,6 +194,7 @@ function addChart(slide, chartData, options) {
     w: options.w || 8,
     h: options.h || 4,
     chartColors: options.chartColors || config.charts.defaultColors,
+    placeholder: options.placeholder || false,
   };
 
   if (options.showLegend !== undefined) {


### PR DESCRIPTION
Previously, it was not possible to insert charts using placeholders. This commit fixes this.